### PR TITLE
modify DB schema and code changes to handle new schema

### DIFF
--- a/entity/tag.go
+++ b/entity/tag.go
@@ -1,10 +1,12 @@
 package entity
 
 type Tag struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
 }
 
 type TagClient struct {
-	Name string `json:"tagName"`
+	Name  string `json:"tagName"`
+	Count int64  `json:"count"`
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/google/uuid v1.1.2
 	google.golang.org/api v0.59.0
+	google.golang.org/genproto v0.0.0-20211028162531-8db9c33dc351
+	google.golang.org/grpc v1.40.0
 )
 
 require (
@@ -24,7 +26,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20211028162531-8db9c33dc351 // indirect
-	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/repository/tag.go
+++ b/repository/tag.go
@@ -6,4 +6,5 @@ type TagRepository interface {
 	Save(tagName string) (*entity.Tag, error)
 	FindAll() ([]entity.Tag, error)
 	FindByName(tagName string) (*entity.Tag, error)
+	UpdateTag(tag *entity.Tag) error
 }


### PR DESCRIPTION
- Tag & TagClient entity now includes 'Count' to keep track of number of snippets with this tag.
- Setting Doc ID to tagName to simplify lookups instead of using random generated IDs.   